### PR TITLE
Fixed warnings given when not all address_components are given

### DIFF
--- a/googlePlaces.php
+++ b/googlePlaces.php
@@ -205,6 +205,12 @@ class googlePlaces
 		if(isset($result['status'])&&$result['status']=='OK' && $this->_apiCallType=='details') {
 			foreach($result['result']['address_components'] as $key=>$component) {
 	
+            $address_street_number='';
+            $address_street_name='';
+            $address_city='';
+            $address_state='';
+            $address_postal_code='';
+   
 				if($component['types'][0]=='street_number') {
 					$address_street_number = $component['short_name'];
 				}


### PR DESCRIPTION
After a "details query" to Google Places, amongst others, address_components is returned. This is an array with different strings. There was no check for that, resulting in warnings when there were NULL strings.
