### PR TITLE
[FEATURE] enable setting of curl referrer: Google checks the referrer…

### DIFF
--- a/src/mills/google-places/googleGeocoding.php
+++ b/src/mills/google-places/googleGeocoding.php
@@ -31,6 +31,7 @@ class googleGeocoding {
     protected $_region;             // The region code, specified as a ccTLD ("top-level domain") two-character value. This parameter will only influence, not fully restrict, results from the geocoder. (For more information see Region Biasing below.)
 
     protected $_curloptSslVerifypeer = true; // option CURLOPT_SSL_VERIFYPEER with true value working not always
+	protected $_curlReferer;
 
     /**
      * constructor - creates a googleGeocoding object with the specified API Key
@@ -160,6 +161,7 @@ class googleGeocoding {
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->_curloptSslVerifypeer);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+		if ($this->_curlReferer) curl_setopt($ch, CURLOPT_REFERER, $this->_curlReferer);
 
         if (!empty($dataToPost)) {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $dataToPost);
@@ -176,6 +178,10 @@ class googleGeocoding {
     /***********************
      * Getters and Setters *
      ***********************/
+
+    public function setCurlReferer($referer) {
+        $this->_curlReferer = $referer;
+    }
 
     public function setAddress($address) {
         $this->_address = urlencode($address);

--- a/src/mills/google-places/googlePlaces.php
+++ b/src/mills/google-places/googlePlaces.php
@@ -33,6 +33,7 @@ class googlePlaces
     protected $_accuracy;
     protected $_pageToken;
     protected $_curloptSslVerifypeer = true; // option CURLOPT_SSL_VERIFYPEER with true value working not always
+	protected $_curlReferer;
 
     /**
      * constructor - creates a googlePlaces object with the specified API Key and with proxy if provided
@@ -377,6 +378,8 @@ class googlePlaces
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->_curloptSslVerifypeer);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+		if ($this->_curlReferer) curl_setopt($ch, CURLOPT_REFERER, $this->_curlReferer);
+		
         if (!empty($topost)) {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $topost);
         }
@@ -410,8 +413,11 @@ class googlePlaces
      * Getters and Setters *
      ***********************/
 
-    public function setLocation($location)
-    {
+ 	public function setCurlReferer($referer) {
+        $this->_curlReferer = $referer;
+    }
+
+    public function setLocation($location) {
         $this->_location = $location;
     }
 


### PR DESCRIPTION
… (the domain that the curl-request is sent from). If it does not match the settings in your Google account, an error is returned. This feature enables setting the referrer so you can use the script i.e. on a dev-server.