### PR TITLE
Use URL encode to encode query parameter.

### DIFF
--- a/src/mills/google-places/googlePlaces.php
+++ b/src/mills/google-places/googlePlaces.php
@@ -426,7 +426,7 @@ class googlePlaces
 
     public function setQuery($query)
     {
-        $this->_query = preg_replace('/\s/', '+', $query);
+        $this->_query = urlencode($query);
     }
 
     public function setRadius($radius)


### PR DESCRIPTION
Special characters like '&' would break the query before this change

The existing replacement, i.e. ` ` to `+` is contained in `urlencode()` as well, see http://php.net/manual/en/function.urlencode.php