### PR TITLE
Add location, radius, and types to autocomplete

### DIFF
--- a/src/mills/google-places/googlePlaces.php
+++ b/src/mills/google-places/googlePlaces.php
@@ -336,7 +336,7 @@ class googlePlaces
                 break;
 
             case(googlePlacesCallType::AUTOCOMPLETE):
-                $parameterString = 'input=' . $this->_query . '&language=' . $this->_language;
+                $parameterString = 'input=' . $this->_query . '&language=' . $this->_language . '&location=' . $this->_location . '&radius=' . $this->_radius . '&types=' . $this->_types;
                 break;
         }
 


### PR DESCRIPTION
These parameters allow autocomplete to work for cities-only and other "types" as defined in the documentation.  Also location and radius allow you to explicitly bias results to a location, but without them, google will dynamically bias your results to your approximate location - which is likely generated from your IP.  With location set to 0,0 and radius 2000000 you can explicitly un-bias the results.